### PR TITLE
Make `npm repo` open the Github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jacobbuck/react-beforeunload.git"
+    "url": "https://github.com/jacobbuck/react-beforeunload"
   },
   "keywords": [
     "beforeunload",


### PR DESCRIPTION
This simple change makes `npm repo react-beforeunload` open the Github repository for the package in the users default browser. This should not have any side effects.